### PR TITLE
Wiz IoT devices

### DIFF
--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -314,6 +314,7 @@ pub mod roborock_vacuum;
 pub mod roku;
 pub mod sonos_speaker;
 pub mod tasmota;
+pub mod wiz;
 
 // Printer
 pub mod cups;

--- a/backend/src/server/services/definitions/wiz.rs
+++ b/backend/src/server/services/definitions/wiz.rs
@@ -1,0 +1,29 @@
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::{Pattern, Vendor};
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct WiZ;
+
+impl ServiceDefinition for WiZ {
+    fn name(&self) -> &'static str {
+        "Wiz"
+    }
+    fn description(&self) -> &'static str {
+        "Wiz IoT Devices"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::IoT
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::MacVendor(Vendor::WIZ)
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/wiz.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<WiZ>));

--- a/backend/src/server/services/impl/patterns.rs
+++ b/backend/src/server/services/impl/patterns.rs
@@ -230,6 +230,7 @@ impl Vendor {
     pub const ECOBEE: &'static str = "ecobee inc";
     pub const ROKU: &'static str = "Roku, Inc";
     pub const ROBOROCK: &'static str = "Beijing Roborock Technology Co., Ltd.";
+    pub const WIZ: &'static str = "WiZ";
 }
 
 impl PartialEq for Pattern<'_> {


### PR DESCRIPTION
Description: WiZ makes IoT Smart LED Bulbs

Official Website: https://www.wizconnected.com

Default Ports:
None

Discovery Method:

Pattern type: Vendor MAC address (WiZ)
Reasoning: Identify WiZ IoT devices (smart LED bulbs) via vendor MAC address

Icon Source: 

Testing:

[Y] Compiles successfully
[Y] Tested against real instance
[N] Unable to test

Testing Details:
Tests positive in dev env... vendor is detected and vendor logo is applied to the corresponding host's services.

Additional Notes:
None