### PR TITLE
fix(auth): allow registration via valid invite when disable_registration=true

### DIFF
--- a/backend/src/server/auth/handlers.rs
+++ b/backend/src/server/auth/handlers.rs
@@ -23,7 +23,7 @@ use crate::server::{
         types::{CredentialType, SecretValue},
     },
     daemon_api_keys::r#impl::base::{DaemonApiKey, DaemonApiKeyBase},
-    invites::handlers::process_pending_invite,
+    invites::{handlers::process_pending_invite, service::InviteService},
     networks::r#impl::{Network, NetworkBase},
     shared::api_key_common::{ApiKeyType, generate_api_key_for_storage},
     shared::{
@@ -72,6 +72,44 @@ fn is_demo_host(host: &str) -> bool {
 fn is_demo_only_host(host: &str) -> bool {
     let hostname = host.split(':').next().unwrap_or(host);
     hostname == DEMO_ONLY_HOST
+}
+
+/// Read `pending_invite_id` from session. Returns None on absence or storage error.
+async fn extract_pending_invite_id(session: &Session) -> Option<Uuid> {
+    session
+        .get::<Uuid>("pending_invite_id")
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Returns `Some(invite_id)` iff the session carries a still-valid pending invite.
+///
+/// Used to authorize registration when `disable_registration: true` — a valid invite
+/// (issued by an authenticated admin) IS the registration authorization. Re-validates
+/// at call-time via `get_valid_invite` so a session field cannot replay an invite
+/// that has been deleted (consumed by `use_invite`, revoked, or expired — single-use
+/// and revocation are implemented as row deletions in `invite_service`).
+///
+/// Fail-closed: any error from session storage or the invite service results in
+/// `None`. Storage errors are logged at WARN so operators can distinguish "no invite
+/// in session" from "invite lookup is broken".
+async fn has_valid_pending_invite(
+    session: &Session,
+    invite_service: &InviteService,
+) -> Option<Uuid> {
+    let invite_id = extract_pending_invite_id(session).await?;
+    match invite_service.get_valid_invite(invite_id).await {
+        Ok(_) => Some(invite_id),
+        Err(e) => {
+            tracing::warn!(
+                invite_id = %invite_id,
+                error = %e,
+                "invite lookup failed during disable_registration bypass check",
+            );
+            None
+        }
+    }
 }
 
 pub fn create_router() -> OpenApiRouter<Arc<AppState>> {
@@ -169,10 +207,24 @@ async fn register(
     }
 
     if state.config.disable_registration {
-        return Err(ApiError::coded(
-            StatusCode::FORBIDDEN,
-            ErrorCode::AuthRegistrationDisabled,
-        ));
+        match has_valid_pending_invite(&session, &state.services.invite_service).await {
+            Some(invite_id) => {
+                // invite_id alone is sufficient for audit trail (join with invites
+                // table to find inviter + invitee email). Email omitted to avoid
+                // PII at INFO level.
+                tracing::info!(
+                    invite_id = %invite_id,
+                    path = "password",
+                    "registration bypassed by valid pending invite",
+                );
+            }
+            None => {
+                return Err(ApiError::coded(
+                    StatusCode::FORBIDDEN,
+                    ErrorCode::AuthRegistrationDisabled,
+                ));
+            }
+        }
     }
 
     // Honeypot: hidden field filled = likely bot (cloud only — self-hosted has no public signup)
@@ -1036,10 +1088,22 @@ async fn oidc_authorize(
             }
 
             if state.config.disable_registration {
-                return Err(ApiError::coded(
-                    StatusCode::FORBIDDEN,
-                    ErrorCode::AuthRegistrationDisabled,
-                ));
+                match has_valid_pending_invite(&session, &state.services.invite_service).await {
+                    Some(invite_id) => {
+                        tracing::info!(
+                            invite_id = %invite_id,
+                            path = "oidc",
+                            provider = %slug,
+                            "registration bypassed by valid pending invite",
+                        );
+                    }
+                    None => {
+                        return Err(ApiError::coded(
+                            StatusCode::FORBIDDEN,
+                            ErrorCode::AuthRegistrationDisabled,
+                        ));
+                    }
+                }
             }
 
             let terms_accepted = params.terms_accepted.unwrap_or(false);
@@ -1664,6 +1728,55 @@ mod tests {
                 !mailchecker::is_valid(email),
                 "{} should be blocked as disposable",
                 email
+            );
+        }
+    }
+
+    mod extract_pending_invite_id_tests {
+        use super::super::extract_pending_invite_id;
+        use std::sync::Arc;
+        use tower_sessions::{MemoryStore, Session};
+        use uuid::Uuid;
+
+        fn new_test_session() -> Session {
+            Session::new(None, Arc::new(MemoryStore::default()), None)
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_session_has_no_invite_key() {
+            let session = new_test_session();
+            assert_eq!(extract_pending_invite_id(&session).await, None);
+        }
+
+        #[tokio::test]
+        async fn returns_some_when_session_has_valid_uuid() {
+            let session = new_test_session();
+            let stored = Uuid::new_v4();
+            session.insert("pending_invite_id", stored).await.unwrap();
+            assert_eq!(extract_pending_invite_id(&session).await, Some(stored));
+        }
+
+        #[tokio::test]
+        async fn returns_none_when_stored_value_is_wrong_type() {
+            let session = new_test_session();
+            // Store a String under the key — Uuid deserialization must fail gracefully.
+            session
+                .insert("pending_invite_id", "not-a-uuid".to_string())
+                .await
+                .unwrap();
+            assert_eq!(extract_pending_invite_id(&session).await, None);
+        }
+
+        #[tokio::test]
+        async fn returns_exact_stored_value() {
+            let session = new_test_session();
+            let stored: Uuid = "12345678-1234-1234-1234-123456789abc".parse().unwrap();
+            session.insert("pending_invite_id", stored).await.unwrap();
+            let retrieved = extract_pending_invite_id(&session).await.unwrap();
+            assert_eq!(retrieved, stored);
+            assert_eq!(
+                retrieved.to_string(),
+                "12345678-1234-1234-1234-123456789abc"
             );
         }
     }

--- a/backend/src/server/invites/handlers.rs
+++ b/backend/src/server/invites/handlers.rs
@@ -538,10 +538,19 @@ pub async fn process_pending_invite(
         _ => return Ok(None), // No network ids
     };
 
-    // Mark invite as used
-    if let Err(e) = state.services.invite_service.use_invite(invite_id).await {
-        tracing::error!("Failed to mark invite as used: {}", e);
-    }
+    // Mark invite as used. Failure is fatal: prevents TOCTOU where an invite gets
+    // consumed/revoked between authorization (e.g. has_valid_pending_invite in the
+    // register handler) and this consumption point. If we swallowed this error, a
+    // deleted invite would still result in user creation + org assignment.
+    state
+        .services
+        .invite_service
+        .use_invite(invite_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(invite_id = %invite_id, error = %e, "invite consumption failed (TOCTOU race or revoked)");
+            Error::msg(format!("invite {} consumption failed: {}", invite_id, e))
+        })?;
 
     // Emit InviteAccepted telemetry event if this is the first accepted invite
     let organization = state


### PR DESCRIPTION
Closes #604

## Summary

- Bypass `disable_registration: true` iff the session carries a valid `pending_invite_id` that re-validates at register-time via `invite_service.get_valid_invite()`. A valid invite (issued by an authenticated admin) is the registration authorization.
- Applies to both password register (`/api/auth/register`) and OIDC `flow=register` (`/api/auth/oidc/{slug}/authorize`).
- Includes security-review TOCTOU plug: `use_invite()` failure in `process_pending_invite` is now fatal (was silently swallowed); prevents a deleted/expired invite from still creating a user.
- Fail-closed: any error from session storage or invite service → no bypass, return 403.
- Public/uninvited registration remains blocked.

## Files changed

| File | LOC | What |
|---|---|---|
| `backend/src/server/auth/handlers.rs` | +131/-9 | 2 helper fns (`extract_pending_invite_id`, `has_valid_pending_invite`) + bypass logic in 2 callsites + 4 unit tests |
| `backend/src/server/invites/handlers.rs` | +14/-3 | TOCTOU fix in `process_pending_invite` |

## Security review

Reviewed by `security-reviewer` agent. Findings addressed in-PR:

| # | Severity | Finding | Resolution |
|---|---|---|---|
| HIGH-2 | 🔴 | `use_invite()` swallowed silently → deleted invite could still create user | Made fatal; pre-user-creation → no orphan record |
| HIGH-1 | 🟠 | Docstring claimed expired/used/revoked but `is_valid()` only checks expiry | Clarified that revocation = row deletion in `invite_service` |
| MEDIUM-1 | 🟡 | `email` logged at INFO (PII risk in centralized logging) | Dropped; `invite_id` alone is sufficient audit join key |
| MEDIUM-2 | 🟡 | `.ok()` swallowed storage errors → operators couldn't distinguish "no invite" from "DB down" | WARN log on `get_valid_invite` Err |
| LOW-1 | ✅ | All other registration guards preserved | Verified: demo-host, password-login, honeypot, terms, email-validity all fire after bypass |

Deferred to follow-up issue (not this PR): "invite link = bearer token for becoming the invited user under any email" — pre-existing behavior; warrants its own ADR + scope to bind `invite.send_to` if present.

## Test plan

### Automated (in-PR)

- [x] `cargo fmt` — clean
- [x] `cargo clippy --bin server -- -D warnings` — No issues
- [x] `cargo clippy --bin daemon -- -D warnings` — No issues
- [x] 4 new unit tests in `extract_pending_invite_id_tests` module (session present/absent/wrong-type/exact-value) → all pass
- [x] `cargo test --lib` — 308 pass, 3 pre-existing Docker-dependent failures (unrelated, see `test_database_schema_backward_compatibility`)

### Staging smoke test (operator — TO RUN before production deploy)

Target: staging instance with `disable_registration: true`.

- [ ] **(a) Valid invite → success**: admin creates invite via `POST /api/v1/invites`, sends URL to test invitee. Invitee in fresh browser session clicks URL, lands on `/onboarding`, completes register → `201` + user object returned. User appears in NetBox with correct org membership.
- [ ] **(b) Anonymous direct → 403**: in fresh browser, `curl -X POST /api/auth/register -d '{"email":"x@y.com","password":"..."}'` (no session cookie) → returns `403 AuthRegistrationDisabled`.
- [ ] **(c) Config unchanged**: `curl /api/config | jq .data.disable_registration` returns `true`. The bypass did not toggle the global flag.
- [ ] **(d) Audit log present**: server logs show `tracing::info!` line `"registration bypassed by valid pending invite"` with `invite_id` + `path=password` (or `path=oidc`) on successful (a).
- [ ] **(e) Invite single-use**: re-using the same invite URL after (a) → 403 (invite was consumed by `use_invite`).

### Coverage gap (documented)

Integration test for `has_valid_pending_invite` would require Docker-Compose stack with custom config OR an InviteService trait refactor (~200 LOC). Per `/design` Decision-3, this gap is covered by staging smoke (e) — invite-already-used path. Track as follow-up if more thorough integration coverage becomes needed.

## Production rollout

1. PR merge → CI build → image push to Harbor
2. Staging deploy: `export DEPLOY_HOST="10.99.201.129" && ./scripts/deploy.sh`
3. Run smoke test plan (a)–(e) above
4. If green: `./scripts/release.sh <ver> --deploy` (production)
5. Verify: send real invite URL to `noc@somapait.com` test inbox, complete onboarding, confirm user lands in correct org.

## Rollback

`./scripts/deploy.sh --rollback` reverts to previous image. No DB schema changes, no migrations — clean rollback.