### PR TITLE
Tuya Smart IoT devices service definition

### DIFF
--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -320,6 +320,7 @@ pub mod roborock_vacuum;
 pub mod roku;
 pub mod sonos_speaker;
 pub mod tasmota;
+pub mod tuyasmart;
 
 // Printer
 pub mod cups;

--- a/backend/src/server/services/definitions/tuyasmart.rs
+++ b/backend/src/server/services/definitions/tuyasmart.rs
@@ -1,0 +1,33 @@
+use crate::server::ports::r#impl::base::PortType;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::{Pattern, Vendor};
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct TuyaSmart;
+
+impl ServiceDefinition for TuyaSmart {
+    fn name(&self) -> &'static str {
+        "Tuya Smart"
+    }
+    fn description(&self) -> &'static str {
+        "Tuya Smart IoT Devices"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::IoT
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::AllOf(vec![
+            Pattern::MacVendor(Vendor::TUYASMART),
+            Pattern::Port(PortType::new_tcp(6668)),
+        ])
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/tuya-smart-inc.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<TuyaSmart>));

--- a/backend/src/server/services/impl/patterns.rs
+++ b/backend/src/server/services/impl/patterns.rs
@@ -216,6 +216,7 @@ impl Vendor {
     pub const ECOBEE: &'static str = "ecobee inc";
     pub const ROKU: &'static str = "Roku, Inc";
     pub const ROBOROCK: &'static str = "Beijing Roborock Technology Co., Ltd.";
+    pub const TUYASMART: &'static str = "Tuya Smart Inc.";
 }
 
 impl PartialEq for Pattern<'_> {


### PR DESCRIPTION
Description: Tuya Smart Inc. makes IoT Smart LED Bulbs

Official Website: https://residential.tuya.com/

Default Ports:
6668

Discovery Method:

Pattern type: Port (6668) & Vendor (TUYASMART)
Reasoning: Identify Tuya Smart Inc IT devices (smart LED bulbs) via open ports & vendor

Icon Source: https://auth.tuya.com/static/img/common/tuya-icon.png

Testing:

[Y] Compiles successfully
[Y] Tested against real instance
[N] Unable to test

Testing Details:
Tests positive in dev env... port and vendor are detected and vendor logo is applied to the corresponding host.

Additional Notes:
None