### PR TITLE
release: run enum-coexistence tests in separate invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,10 +266,11 @@ jobs:
           DATABASE_URL: ${{ steps.create_branch.outputs.db_url }}
         working-directory: backend
         run: |
-          cargo test --lib \
-            test_current_reads_previous_release_variants \
-            test_current_writes_subset_of_previous_release \
-            -- --ignored
+          # cargo test takes a single [TESTNAME] filter, so run each ignored
+          # coexistence test in its own invocation (two positionals errors out
+          # with "unexpected argument"). The second is a cache hit.
+          cargo test --lib test_current_reads_previous_release_variants -- --ignored
+          cargo test --lib test_current_writes_subset_of_previous_release -- --ignored
 
       - name: Delete Neon branch
         if: always()


### PR DESCRIPTION
- cargo test accepts only one [TESTNAME] filter; passing both test_current_reads_* and test_current_writes_* as positionals errored with 'unexpected argument'. Split into two invocations (second is a cache hit). This step never ran before — the harness failed ahead of it.