### PR TITLE
chore: regenerate db_enum_baseline for v0.17.7

### DIFF
--- a/backend/tests/fixtures/db_enum_baseline.json
+++ b/backend/tests/fixtures/db_enum_baseline.json
@@ -168,5 +168,5 @@
     "Workloads",
     "Application"
   ],
-  "_note": "Extra variants beyond the current binary's VARIANTS list are preserved across regens for #[serde(alias = \"\u2026\")] tolerance. To accept a breaking rename, delete the old entry from this file manually and declare Deploy-Mode: downtime for the release."
+  "_note": "Extra variants beyond the current binary's VARIANTS list are preserved across regens for #[serde(alias = \"…\")] tolerance. To accept a breaking rename, delete the old entry from this file manually and declare Deploy-Mode: downtime for the release."
 }


### PR DESCRIPTION
Automated baseline refresh after v0.17.7 was published. Merges the new set of DB-backed enum variants into the baseline so the next release cycle's coexistence checks compare against the just-released binary.$'\n\n'Review: confirm the diff matches the enum changes in this release. If a rename shipped with a `#[serde(alias)]`, keep the old name in the fixture manually.