### PR TITLE
chore: regenerate db_enum_baseline for v0.17.11

### DIFF
--- a/backend/tests/fixtures/db_enum_baseline.json
+++ b/backend/tests/fixtures/db_enum_baseline.json
@@ -48,7 +48,8 @@
     "PodmanProxy",
     "PodmanSocket",
     "UnifiApiKey",
-    "UnifiLocalAdmin"
+    "UnifiLocalAdmin",
+    "InstantOnAccount"
   ],
   "DaemonMode": [
     "ServerPoll",


### PR DESCRIPTION
Automated baseline refresh after v0.17.11 was published. Merges the new set of DB-backed enum variants into the baseline so the next release cycle's coexistence checks compare against the just-released binary.$'\n\n'Review: confirm the diff matches the enum changes in this release. If a rename shipped with a `#[serde(alias)]`, keep the old name in the fixture manually.