### PR TITLE
Fall back to LLDP-V2-MIB when the classic remote table yields nothing (#688)

### DIFF
--- a/backend/src/daemon/discovery/integration/snmp/mod.rs
+++ b/backend/src/daemon/discovery/integration/snmp/mod.rs
@@ -374,6 +374,7 @@ impl DiscoveryIntegration for SnmpIntegration {
         let lldp_authoritative = lldp.complete && !lldp.unsupported;
         let lldp_discarded = lldp.discarded;
         let lldp_discard_reason = lldp.discard_reason;
+        let lldp_local_port_is_if_index = lldp.local_port_is_if_index;
         let mut lldp_neighbors = lldp.records;
         tracing::debug!(
             ip = %ip,
@@ -438,8 +439,10 @@ impl DiscoveryIntegration for SnmpIntegration {
         // that reports lldpLocPortNum == ifIndex or omits the table). CDP is not
         // remapped: cdpCacheIfIndex is already a real ifIndex.
         // Not walked at all when there is no neighbour to place, so its outcome is "nothing to
-        // ask" rather than a complete read of an empty table.
-        let lldp_local_ports = if lldp_count > 0 {
+        // ask" rather than a complete read of an empty table. Nor when the neighbours came from
+        // the LLDP-V2-MIB (GH #688): `lldpV2RemLocalIfIndex` is already an ifIndex, and the
+        // classic `lldpLocPortTable` is not a table such a device serves.
+        let lldp_local_ports = if lldp_count > 0 && !lldp_local_port_is_if_index {
             query_or_default(
                 ip,
                 "lldp_local_ports",
@@ -456,8 +459,20 @@ impl DiscoveryIntegration for SnmpIntegration {
             claim: lldp_local_ports.claim,
         };
         let lldp_local_ports = lldp_local_ports.records;
-        let local_ports =
-            remap_lldp_local_ports(&mut lldp_neighbors, &lldp_local_ports, &snmp_if_entries);
+        let local_ports = if lldp_local_port_is_if_index {
+            // Nothing to translate, but the placement rule still applies: a neighbour on an
+            // ifIndex the interface walk did not return reaches no interface either way.
+            LocalPortOutcome {
+                unmatched: 0,
+                dropped: count_dropped_neighbours(
+                    &lldp_neighbors,
+                    &lldp_local_ports,
+                    &snmp_if_entries,
+                ),
+            }
+        } else {
+            remap_lldp_local_ports(&mut lldp_neighbors, &lldp_local_ports, &snmp_if_entries)
+        };
         if local_ports.unmatched > 0 || local_ports.dropped > 0 {
             tracing::warn!(
                 ip = %ip,

--- a/backend/src/daemon/discovery/integration/snmp/oids.rs
+++ b/backend/src/daemon/discovery/integration/snmp/oids.rs
@@ -234,6 +234,77 @@ pub mod lldp {
     }
 }
 
+/// LLDP-V2-MIB OIDs (IEEE 802.1AB-2009 revision, rooted at 1.3.111.2.802.1.1.13).
+///
+/// Some agents implement only this revision — IP Infusion OcNOS among them (GH #688): every
+/// classic `1.0.8802.1.1.2` remote-table column walks straight into the adjacent `lldpExtensions`
+/// subtree, while the same neighbours sit here, fully populated. The local tables keep the classic
+/// column numbering; the remote entry does not, because `lldpV2RemLocalIfIndex` is inserted as
+/// column 2 and every column after it moves up by one. Verified against OcNOS 7.0.1 on a UfiSpace
+/// S9600-32X.
+pub mod lldp_v2 {
+    /// The LLDP-V2-MIB root, which is the subtree an agent registers to serve it.
+    pub const LLDP_V2_MIB: &str = "1.3.111.2.802.1.1.13";
+
+    /// lldpV2LocalSystemData
+    pub mod local {
+        /// lldpV2LocChassisIdSubtype
+        pub const LLDP_V2_LOC_CHASSIS_ID_SUBTYPE: &str = "1.3.111.2.802.1.1.13.1.3.1.0";
+
+        /// lldpV2LocChassisId
+        pub const LLDP_V2_LOC_CHASSIS_ID: &str = "1.3.111.2.802.1.1.13.1.3.2.0";
+
+        /// lldpV2LocSysName
+        pub const LLDP_V2_LOC_SYS_NAME: &str = "1.3.111.2.802.1.1.13.1.3.3.0";
+
+        /// lldpV2LocSysDesc
+        pub const LLDP_V2_LOC_SYS_DESC: &str = "1.3.111.2.802.1.1.13.1.3.4.0";
+
+        /// lldpV2LocPortIdSubtype — `lldpV2LocPortTable` is indexed by `lldpV2LocPortIfIndex`,
+        /// a real ifIndex, unlike the classic table's `lldpLocPortNum`.
+        pub const LLDP_V2_LOC_PORT_ID_SUBTYPE: &str = "1.3.111.2.802.1.1.13.1.3.7.1.2";
+
+        /// lldpV2LocPortId
+        pub const LLDP_V2_LOC_PORT_ID: &str = "1.3.111.2.802.1.1.13.1.3.7.1.3";
+
+        /// lldpV2LocPortDesc
+        pub const LLDP_V2_LOC_PORT_DESC: &str = "1.3.111.2.802.1.1.13.1.3.7.1.4";
+    }
+
+    /// lldpV2RemoteSystemsData
+    pub mod remote {
+        /// lldpV2RemEntry columns. Each sits one above its classic counterpart, and the row index
+        /// is `lldpV2RemTimeMark.lldpV2RemLocalIfIndex.lldpV2RemLocalDestMACAddress.lldpV2RemIndex`
+        /// — four sub-ids, the third a row pointer into `lldpV2DestAddressTable`.
+        pub mod entry {
+            /// lldpV2RemChassisIdSubtype
+            pub const LLDP_V2_REM_CHASSIS_ID_SUBTYPE: &str = "1.3.111.2.802.1.1.13.1.4.1.1.5";
+
+            /// lldpV2RemChassisId
+            pub const LLDP_V2_REM_CHASSIS_ID: &str = "1.3.111.2.802.1.1.13.1.4.1.1.6";
+
+            /// lldpV2RemPortIdSubtype
+            pub const LLDP_V2_REM_PORT_ID_SUBTYPE: &str = "1.3.111.2.802.1.1.13.1.4.1.1.7";
+
+            /// lldpV2RemPortId
+            pub const LLDP_V2_REM_PORT_ID: &str = "1.3.111.2.802.1.1.13.1.4.1.1.8";
+
+            /// lldpV2RemPortDesc
+            pub const LLDP_V2_REM_PORT_DESC: &str = "1.3.111.2.802.1.1.13.1.4.1.1.9";
+
+            /// lldpV2RemSysName
+            pub const LLDP_V2_REM_SYS_NAME: &str = "1.3.111.2.802.1.1.13.1.4.1.1.10";
+
+            /// lldpV2RemSysDesc
+            pub const LLDP_V2_REM_SYS_DESC: &str = "1.3.111.2.802.1.1.13.1.4.1.1.11";
+
+            /// lldpV2RemManAddrIfSubtype — an accessible column of `lldpV2RemManAddrTable`; as in
+            /// the classic table, the address itself lives in the OID index.
+            pub const LLDP_V2_REM_MAN_ADDR_IF_SUBTYPE: &str = "1.3.111.2.802.1.1.13.1.4.2.1.3";
+        }
+    }
+}
+
 /// CDP-MIB OIDs (Cisco proprietary)
 pub mod cdp {
     /// The Cisco CDP MIB root, which is the subtree an agent registers to serve the cache table.

--- a/backend/src/daemon/discovery/integration/snmp/queries.rs
+++ b/backend/src/daemon/discovery/integration/snmp/queries.rs
@@ -649,6 +649,16 @@ pub struct SnmpCollection<T> {
     /// asserted that it never would — true of a device serving malformed rows, false of a column
     /// that stopped early, and the two were indistinguishable to the operator (GH #668).
     pub discard_reason: Option<MalformedNeighbourReason>,
+    /// The records' local-port keys are already `ifIndex` values, so the caller must not put
+    /// them through `remap_lldp_local_ports`.
+    ///
+    /// Set only by the LLDP neighbour walk, and only when it read the neighbours from the
+    /// LLDP-V2-MIB (GH #688). `lldpV2RemLocalIfIndex` is an ifIndex by definition, where the
+    /// classic `lldpRemLocalPortNum` is a separate namespace that has to be translated through
+    /// `lldpLocPortTable` — a table a V2-only agent does not serve. Remapping a V2 result would
+    /// treat a real ifIndex as a port number: identity on most firmware, and wrong on exactly the
+    /// vendors the remap exists for. `false` everywhere else, where nothing consumes it.
+    pub local_port_is_if_index: bool,
 }
 
 impl<T: Default> SnmpCollection<T> {
@@ -666,6 +676,7 @@ impl<T: Default> SnmpCollection<T> {
             discarded: 0,
             discard_reason: None,
             claim: None,
+            local_port_is_if_index: false,
         }
     }
 }
@@ -685,6 +696,7 @@ impl<T> SnmpCollection<T> {
             discarded: 0,
             discard_reason: None,
             claim: None,
+            local_port_is_if_index: false,
         }
     }
 }
@@ -698,6 +710,7 @@ impl<T: Default> Default for SnmpCollection<T> {
             discarded: 0,
             discard_reason: None,
             claim: None,
+            local_port_is_if_index: false,
             // `query_or_default` produces this when a whole query timed out or errored, and it
             // genuinely cannot say more — the future was dropped before it could report.
             reason: Some(ShortfallReason::NoAnswer),
@@ -1030,12 +1043,59 @@ pub async fn walk_if_table<T: SnmpWalkTransport>(
     })
 }
 
-/// Query LLDP remote table for neighbor information
+/// Query LLDP remote table for neighbor information.
+///
+/// The classic LLDP-MIB is walked first, and the LLDP-V2-MIB only when that walk finished and
+/// found nothing (GH #688). The two are never merged: a device that serves both serves the same
+/// neighbours twice, under different keys, and the classic result is the one every existing
+/// device is read through.
 pub async fn query_lldp_neighbors<T: SnmpWalkTransport>(
     session: &mut T,
     ip: IpAddr,
 ) -> Result<SnmpCollection<Vec<LldpNeighbor>>> {
-    query_lldp_neighbors_for(session, ip, &CLASSIC_LLDP_MIB).await
+    let classic = query_lldp_neighbors_for(session, ip, &CLASSIC_LLDP_MIB).await?;
+
+    // A classic walk that read nothing can mean three different agents: one with no LLDP at all,
+    // one whose table is implemented and empty, and one that implements only the 802.1AB-2009
+    // revision of the MIB under 1.3.111. The third cannot be told from the first two by the stop
+    // reason: `unsupported` covers an agent that answers `noSuchObject`, but IP Infusion OcNOS
+    // serves the `lldpExtensions` subtree under the classic root, so its classic columns end
+    // `EndOfSubtree` — "implemented and empty" — and `unsupported` stays false. Zero rows from a
+    // finished walk is therefore the gate, deliberately wider than `unsupported`: every device
+    // whose classic table is implemented and empty — a host, a printer, a switch with nothing
+    // plugged in — pays for it with eight single-page walks (the seven remote columns and the
+    // management-address table) that find nothing.
+    //
+    // A walk that did *not* finish is a different matter. Its empty result is a read that failed,
+    // not a device that has nothing, and falling back on it would let a V2 walk — or, worse, an
+    // equally empty one — stand in for neighbours the classic table holds.
+    if !classic.complete || !classic.records.is_empty() {
+        return Ok(classic);
+    }
+
+    let mut v2 = query_lldp_neighbors_for(session, ip, &V2_LLDP_MIB).await?;
+    // Only a V2 walk that finished and read nothing at all yields to the classic verdict. That
+    // verdict is kept on purpose: an equally empty fallback must not launder an agent with no
+    // LLDP into a supported-but-empty one, which would give the server authority to clear the
+    // neighbours another integration wrote for it.
+    //
+    // A V2 walk that came up short is the opposite case and must *not* yield. On a V2-only
+    // device the classic result is complete and not unsupported — the empty table the server
+    // treats as authoritative — so handing it back after a transient V2 stall would clear the
+    // edges the previous scan wrote. The incomplete V2 result goes back instead, empty and
+    // marked as such. Rows the walk read and had to discard are likewise the device's own,
+    // and the discard is what the operator needs told.
+    if v2.complete && v2.records.is_empty() && v2.discarded == 0 {
+        return Ok(classic);
+    }
+    debug!(
+        ip = %ip,
+        neighbors = v2.records.len(),
+        complete = v2.complete,
+        "classic LLDP-MIB empty; neighbours read from LLDP-V2-MIB"
+    );
+    v2.local_port_is_if_index = true;
+    Ok(v2)
 }
 
 /// The neighbour walk, against whichever LLDP MIB `mib` names.
@@ -1306,6 +1366,7 @@ pub async fn query_lldp_neighbors_for<T: SnmpWalkTransport>(
         // The LLDP/CDP claim is the device's own local identity, which is read later in the
         // collection than this walk, so the caller attaches it.
         claim: None,
+        local_port_is_if_index: false,
     })
 }
 
@@ -1431,6 +1492,113 @@ fn split_lldp_man_addr_index(suffix: &[u64]) -> Option<(i32, i32, Vec<u8>)> {
         return Some((suffix[prefix - 2] as i32, suffix[prefix - 1] as i32, buf));
     }
     None
+}
+
+/// The LLDP-V2-MIB, `1.3.111.2.802.1.1.13` (GH #688).
+///
+/// Walked only as a fallback — see [`query_lldp_neighbors`] — and never through the classic
+/// splitters: its remote entry has one more index sub-id and one more column than the classic
+/// one, and its local identifier is an ifIndex rather than an `lldpLocPortNum`.
+pub static V2_LLDP_MIB: LldpMibProfile = LldpMibProfile {
+    remote_columns: [
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_CHASSIS_ID_SUBTYPE,
+            "remChassisIdSubtype",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_CHASSIS_ID,
+            "remChassisId",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_PORT_ID_SUBTYPE,
+            "remPortIdSubtype",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_PORT_ID,
+            "remPortId",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_PORT_DESC,
+            "remPortDesc",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_SYS_NAME,
+            "remSysName",
+        ),
+        (
+            oids::lldp_v2::remote::entry::LLDP_V2_REM_SYS_DESC,
+            "remSysDesc",
+        ),
+    ],
+    split_rem_index: split_lldp_v2_rem_index,
+    man_addr_column: oids::lldp_v2::remote::entry::LLDP_V2_REM_MAN_ADDR_IF_SUBTYPE,
+    split_man_addr_index: split_lldp_v2_man_addr_index,
+};
+
+/// Split an `lldpV2RemEntry` OID index into `(lldpV2RemLocalIfIndex, lldpV2RemIndex)`.
+///
+/// The index is `timeMark.localIfIndex.localDestMACAddress.remIndex`, read from the front and
+/// required whole. This is deliberately not [`split_lldp_rem_index`], which reads its pair off
+/// the end to tolerate an omitted time mark: applied to a four-sub-id V2 index that returns
+/// `(destAddressIndex, remIndex)`, collapsing every neighbour on the device onto the
+/// destination-address index — 1, the nearest-bridge group address — and discarding all but one
+/// as duplicates, silently. No V2 firmware has been seen omitting the time mark, and guessing at
+/// a three-sub-id layout would re-open exactly that ambiguity, so a short or long index is
+/// counted in `short_index` rather than parsed.
+fn split_lldp_v2_rem_index(suffix: &[u64]) -> Option<(i32, i32)> {
+    match suffix {
+        [_time_mark, local_if_index, _dest_mac_index, rem_index] => {
+            Some((*local_if_index as i32, *rem_index as i32))
+        }
+        _ => None,
+    }
+}
+
+/// Split an `lldpV2RemManAddrTable` OID index into its neighbour key and management address.
+///
+/// The index is `timeMark.ifIndex.destMacIndex.remIndex.addrSubtype.addrLen.addr…`, and the
+/// conformant layout is tried first, accepted only when the declared length accounts for exactly
+/// the sub-ids that follow. The firmware this was written against (IP Infusion OcNOS 7.0.1) serves
+/// **no address-length sub-identifier** — the address bytes simply run to the end of the index —
+/// so that layout is the fallback:
+///
+/// ```text
+///   1.3.111...13.1.4.2.1.3.0.10009.1.6.1.192.0.2.102   (ifIndex 10009, remIndex 6, IPv4)
+///   1.3.111...13.1.4.2.1.3.0.3.1.4.2                   (a row with subtype but no address)
+/// ```
+///
+/// The second shape yields an empty address buffer, which `parse_lldp_mgmt_addr` rejects — the
+/// right outcome for a row that carries nothing to resolve. The two layouts are ambiguous in one
+/// case: a length-less address whose first octet happens to equal the count of octets after it
+/// (an IPv4 address starting with 3) parses as conformant and loses that octet, and
+/// `parse_lldp_mgmt_addr` then rejects the three-byte IPv4 — so the row resolves to no address,
+/// never to a wrong one.
+///
+/// Returns `(ifIndex, remIndex, [ianaFamily, addr bytes...])` — the byte buffer
+/// `parse_lldp_mgmt_addr` expects.
+fn split_lldp_v2_man_addr_index(suffix: &[u64]) -> Option<(i32, i32, Vec<u8>)> {
+    let [
+        _time_mark,
+        if_index,
+        _dest_mac_index,
+        rem_index,
+        addr_subtype,
+        rest @ ..,
+    ] = suffix
+    else {
+        return None;
+    };
+    let mut buf = Vec::with_capacity(1 + rest.len());
+    buf.push(*addr_subtype as u8);
+    match rest {
+        // Conformant: the length sub-id is followed by exactly that many address sub-ids.
+        [addr_len, addr @ ..] if *addr_len > 0 && addr.len() == *addr_len as usize => {
+            buf.extend(addr.iter().map(|&b| b as u8));
+        }
+        // Length-less: whatever follows the subtype is the address.
+        addr => buf.extend(addr.iter().map(|&b| b as u8)),
+    }
+    Some((*if_index as i32, *rem_index as i32, buf))
 }
 
 /// The cause that explains most of what a device's LLDP walk threw away.
@@ -1749,6 +1917,7 @@ pub async fn query_cdp_neighbors<T: SnmpWalkTransport>(
         // The LLDP/CDP claim is the device's own local identity, which is read later in the
         // collection than this walk, so the caller attaches it.
         claim: None,
+        local_port_is_if_index: false,
     })
 }
 
@@ -1994,6 +2163,7 @@ pub async fn query_bridge_port_mapping<T: SnmpWalkTransport>(
         discarded: 0,
         discard_reason: None,
         claim,
+        local_port_is_if_index: false,
     })
 }
 
@@ -2130,6 +2300,7 @@ pub async fn query_bridge_fdb<T: SnmpWalkTransport>(
         discarded: 0,
         discard_reason: None,
         claim: None,
+        local_port_is_if_index: false,
     })
 }
 
@@ -2202,6 +2373,7 @@ async fn walk_qbridge_fdb<T: SnmpWalkTransport>(
         discarded: 0,
         discard_reason: None,
         claim: None,
+        local_port_is_if_index: false,
     })
 }
 
@@ -2211,38 +2383,33 @@ pub async fn query_lldp_local<T: SnmpWalkTransport>(
     session: &mut T,
     ip: IpAddr,
 ) -> Result<Option<LldpLocalInfo>> {
-    // GET lldpLocChassisIdSubtype
-    let subtype = match session
-        .get_scalar(&oids::oid_parts(
-            oids::lldp::local::LLDP_LOC_CHASSIS_ID_SUBTYPE,
-        ))
-        .await
-    {
-        Ok(value) => value
-            .and_then(|value| value_to_i32(&value))
-            .map(|v| v as u8),
-        Err(e) => {
-            debug!(
-                "LLDP local chassis ID subtype GET failed from {}: {}",
-                ip, e
-            );
-            None
-        }
-    };
+    let (subtype, chassis_bytes) = get_lldp_local_chassis(
+        session,
+        ip,
+        oids::lldp::local::LLDP_LOC_CHASSIS_ID_SUBTYPE,
+        oids::lldp::local::LLDP_LOC_CHASSIS_ID,
+    )
+    .await;
 
-    // GET lldpLocChassisId
-    let chassis_bytes = match session
-        .get_scalar(&oids::oid_parts(oids::lldp::local::LLDP_LOC_CHASSIS_ID))
-        .await
-    {
-        Ok(value) => value.and_then(|value| match value {
-            Value::OctetString(bytes) => Some(bytes.to_vec()),
-            _ => None,
-        }),
-        Err(e) => {
-            debug!("LLDP local chassis ID GET failed from {}: {}", ip, e);
-            None
+    // The same fallback as `query_lldp_neighbors`, for the same agents (GH #688). A device whose
+    // LLDP lives only under the V2 root has no classic `lldpLocChassisId` either, and without its
+    // own identity it can sit in every other device's neighbour table yet never resolve as
+    // itself. Two scalar GETs, attempted only when the classic pair returned nothing.
+    let (subtype, chassis_bytes) = match (subtype, chassis_bytes) {
+        (None, None) => {
+            let v2 = get_lldp_local_chassis(
+                session,
+                ip,
+                oids::lldp_v2::local::LLDP_V2_LOC_CHASSIS_ID_SUBTYPE,
+                oids::lldp_v2::local::LLDP_V2_LOC_CHASSIS_ID,
+            )
+            .await;
+            if v2.0.is_some() || v2.1.is_some() {
+                debug!("LLDP local identity read from LLDP-V2-MIB for {}", ip);
+            }
+            v2
         }
+        classic => classic,
     };
 
     match (subtype, chassis_bytes) {
@@ -2263,6 +2430,42 @@ pub async fn query_lldp_local<T: SnmpWalkTransport>(
             Ok(None)
         }
     }
+}
+
+/// GET the two scalars that make up a device's own LLDP chassis identity, from whichever MIB
+/// revision `subtype_oid`/`chassis_oid` name. Either half is `None` when the agent does not
+/// serve it, answers with the wrong type, or fails the request.
+async fn get_lldp_local_chassis<T: SnmpWalkTransport>(
+    session: &mut T,
+    ip: IpAddr,
+    subtype_oid: &str,
+    chassis_oid: &str,
+) -> (Option<u8>, Option<Vec<u8>>) {
+    let subtype = match session.get_scalar(&oids::oid_parts(subtype_oid)).await {
+        Ok(value) => value
+            .and_then(|value| value_to_i32(&value))
+            .map(|v| v as u8),
+        Err(e) => {
+            debug!(
+                "LLDP local chassis ID subtype GET failed from {}: {}",
+                ip, e
+            );
+            None
+        }
+    };
+
+    let chassis_bytes = match session.get_scalar(&oids::oid_parts(chassis_oid)).await {
+        Ok(value) => value.and_then(|value| match value {
+            Value::OctetString(bytes) => Some(bytes.to_vec()),
+            _ => None,
+        }),
+        Err(e) => {
+            debug!("LLDP local chassis ID GET failed from {}: {}", ip, e);
+            None
+        }
+    };
+
+    (subtype, chassis_bytes)
 }
 
 /// Query VLAN table for VLAN IDs and names.
@@ -2358,6 +2561,7 @@ pub async fn query_port_vlan_membership<T: SnmpWalkTransport>(
             discarded: 0,
             discard_reason: None,
             claim: None,
+            local_port_is_if_index: false,
         });
     }
 
@@ -2468,6 +2672,7 @@ pub async fn query_port_vlan_membership<T: SnmpWalkTransport>(
         discarded: 0,
         discard_reason: None,
         claim: None,
+        local_port_is_if_index: false,
     })
 }
 
@@ -4168,5 +4373,323 @@ mod out_of_order_tests {
 
         assert_eq!(count, MAX_WALK_ENTRIES);
         assert!(!stop.is_complete(), "a capped walk is not a finished one");
+    }
+}
+
+#[cfg(test)]
+mod lldp_v2_tests {
+    use super::*;
+
+    /// A value an agent can return; `Value` borrows, so test data is `'static`.
+    #[derive(Clone)]
+    enum Canned {
+        Int(i64),
+        Str(&'static str),
+        Bytes(&'static [u8]),
+    }
+
+    /// Same shape as `if_table_tests::FakeAgent`: a sorted OID table answered the way a real
+    /// agent pages a walk, with EndOfMibView past the last row so absent subtrees read as
+    /// unsupported rather than truncated.
+    ///
+    /// A request under `stalls` gets no answer at all, which is how a walk of that subtree is
+    /// made to come up short without touching any other.
+    struct Agent {
+        rows: Vec<(Vec<u64>, Canned)>,
+        stalls: Option<Vec<u64>>,
+    }
+
+    impl Agent {
+        fn new(rows: &[(&str, Canned)]) -> Self {
+            let mut rows: Vec<(Vec<u64>, Canned)> = rows
+                .iter()
+                .map(|(oid, v)| (oids::oid_parts(oid), v.clone()))
+                .collect();
+            rows.sort_by(|a, b| a.0.cmp(&b.0));
+            Self { rows, stalls: None }
+        }
+
+        fn stalling_under(mut self, subtree: &str) -> Self {
+            self.stalls = Some(oids::oid_parts(subtree));
+            self
+        }
+
+        fn page(&self, from: &[u64]) -> Result<Varbinds<'_>> {
+            if let Some(stalled) = &self.stalls
+                && from.starts_with(stalled)
+            {
+                anyhow::bail!("timed out");
+            }
+            let page: Varbinds<'_> = self
+                .rows
+                .iter()
+                .filter(|(oid, _)| oid.as_slice() > from)
+                .take(BULK_MAX_REPETITIONS as usize)
+                .map(|(oid, v)| {
+                    let value = match v {
+                        Canned::Int(i) => Value::Integer(*i),
+                        Canned::Str(s) => Value::OctetString(s.as_bytes()),
+                        Canned::Bytes(b) => Value::OctetString(b),
+                    };
+                    (oid.clone(), value)
+                })
+                .collect();
+            if page.is_empty() {
+                return Ok(vec![(from.to_vec(), Value::EndOfMibView)]);
+            }
+            Ok(page)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SnmpWalkTransport for Agent {
+        async fn walk_getbulk<'a>(&'a mut self, from: &[u64], _max: u32) -> Result<WalkPage<'a>> {
+            Ok(WalkPage::Varbinds(self.page(from)?))
+        }
+
+        async fn walk_getnext<'a>(&'a mut self, from: &[u64]) -> Result<Varbinds<'a>> {
+            self.page(from)
+        }
+    }
+
+    fn ip() -> IpAddr {
+        "192.0.2.1".parse().unwrap()
+    }
+
+    /// The rows an OcNOS 7.0.1 agent actually served (UfiSpace S9600-32X, `snmpwalk -On`,
+    /// 2026-08-24; identifiers rewritten): three neighbours indexed
+    /// `timeMark.ifIndex.destMacIndex.remIndex`, chassis ids as MAC octets, and a
+    /// management-address table with no address-length sub-id. Nothing under the classic root.
+    fn ocnos_rows() -> Vec<(&'static str, Canned)> {
+        const CORE: &[u8] = &[0x00, 0x1a, 0x2b, 0x00, 0x10, 0x00];
+        const SPINE1: &[u8] = &[0x00, 0x1a, 0x2b, 0x40, 0xe9, 0xca];
+        const SPINE2: &[u8] = &[0x00, 0x1a, 0x2b, 0x40, 0xd4, 0xca];
+        vec![
+            // chassis subtype (4 = macAddress)
+            ("1.3.111.2.802.1.1.13.1.4.1.1.5.0.3.1.4", Canned::Int(4)),
+            ("1.3.111.2.802.1.1.13.1.4.1.1.5.0.10009.1.6", Canned::Int(4)),
+            ("1.3.111.2.802.1.1.13.1.4.1.1.5.0.10073.1.2", Canned::Int(4)),
+            // chassis id
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.6.0.3.1.4",
+                Canned::Bytes(CORE),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.6.0.10009.1.6",
+                Canned::Bytes(SPINE1),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.6.0.10073.1.2",
+                Canned::Bytes(SPINE2),
+            ),
+            // port id subtype / id
+            ("1.3.111.2.802.1.1.13.1.4.1.1.7.0.3.1.4", Canned::Int(7)),
+            ("1.3.111.2.802.1.1.13.1.4.1.1.7.0.10009.1.6", Canned::Int(5)),
+            ("1.3.111.2.802.1.1.13.1.4.1.1.7.0.10073.1.2", Canned::Int(5)),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.8.0.3.1.4",
+                Canned::Str("Ethernet5"),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.8.0.10009.1.6",
+                Canned::Str("swp5"),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.8.0.10073.1.2",
+                Canned::Str("swp5"),
+            ),
+            // sys name
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.10.0.3.1.4",
+                Canned::Str("switch-core-01"),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.10.0.10009.1.6",
+                Canned::Str("switch-arcos-01"),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.1.1.10.0.10073.1.2",
+                Canned::Str("switch-arcos-02"),
+            ),
+            // management addresses: OcNOS layout, address bytes to the end of the index —
+            // and one row that carries a subtype but no address at all.
+            ("1.3.111.2.802.1.1.13.1.4.2.1.3.0.3.1.4.2", Canned::Int(2)),
+            (
+                "1.3.111.2.802.1.1.13.1.4.2.1.3.0.10009.1.6.1.192.0.2.102",
+                Canned::Int(2),
+            ),
+            (
+                "1.3.111.2.802.1.1.13.1.4.2.1.3.0.10073.1.2.1.192.0.2.103",
+                Canned::Int(2),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn v2_only_agent_yields_neighbours_keyed_by_if_index() {
+        let mut agent = Agent::new(&ocnos_rows());
+
+        let got = query_lldp_neighbors(&mut agent, ip()).await.unwrap();
+
+        assert!(!got.unsupported, "an agent serving V2 rows has LLDP");
+        assert!(got.complete);
+        assert_eq!(got.discarded, 0);
+        assert!(
+            got.local_port_is_if_index,
+            "the caller must be told not to remap these"
+        );
+        let mut records = got.records;
+        records.sort_by_key(|n| n.local_port_index);
+        assert_eq!(
+            records
+                .iter()
+                .map(|n| n.local_port_index)
+                .collect::<Vec<_>>(),
+            vec![3, 10009, 10073],
+            "the V2 local identifier is the ifIndex, second from the front"
+        );
+        assert_eq!(
+            records[0].remote_sys_name.as_deref(),
+            Some("switch-core-01")
+        );
+        assert_eq!(
+            records[1].remote_sys_name.as_deref(),
+            Some("switch-arcos-01")
+        );
+        assert_eq!(
+            records[1].remote_port_id_bytes.as_deref(),
+            Some(b"swp5" as &[u8])
+        );
+        assert_eq!(
+            records[1].remote_mgmt_addr,
+            Some("192.0.2.102".parse().unwrap()),
+            "V2 management address reconstructed from a length-less index"
+        );
+        assert!(
+            records[0].remote_mgmt_addr.is_none(),
+            "a management row with no address bytes resolves to nothing, not garbage"
+        );
+    }
+
+    #[tokio::test]
+    async fn classic_agent_never_reaches_the_v2_walk() {
+        // One classic neighbour (index timeMark.localPortNum.remIndex = 0.5.1) — and V2 rows
+        // carrying different sys names. If the fallback ran anyway, the V2 rows would either
+        // merge or collide; the classic result must come back alone and untouched.
+        let mut rows = vec![
+            ("1.0.8802.1.1.2.1.4.1.1.4.0.5.1", Canned::Int(4)),
+            (
+                "1.0.8802.1.1.2.1.4.1.1.5.0.5.1",
+                Canned::Bytes(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+            ),
+            (
+                "1.0.8802.1.1.2.1.4.1.1.9.0.5.1",
+                Canned::Str("classic-peer"),
+            ),
+        ];
+        rows.extend(ocnos_rows());
+        let mut agent = Agent::new(&rows);
+
+        let got = query_lldp_neighbors(&mut agent, ip()).await.unwrap();
+
+        assert_eq!(got.records.len(), 1, "V2 rows must not be merged in");
+        assert_eq!(got.records[0].local_port_index, 5);
+        assert_eq!(
+            got.records[0].remote_sys_name.as_deref(),
+            Some("classic-peer")
+        );
+        assert!(
+            !got.local_port_is_if_index,
+            "a classic result still goes through the local-port remap"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_agent_with_neither_mib_is_still_unsupported() {
+        // No rows at all: the fake then answers EndOfMibView at the first request of every
+        // column, which is the shape `is_unsupported` keys on.
+        let mut agent = Agent::new(&[]);
+
+        let got = query_lldp_neighbors(&mut agent, ip()).await.unwrap();
+
+        assert!(got.records.is_empty());
+        assert!(
+            got.unsupported,
+            "falling back must not turn a no-LLDP agent into a supported-but-empty one"
+        );
+        assert!(!got.local_port_is_if_index);
+    }
+
+    /// An empty classic result from a walk that did not finish is a failed read, not a device
+    /// with nothing — and not a licence to go looking elsewhere. The V2 rows are there to be
+    /// found; the point is that they must not be.
+    #[tokio::test]
+    async fn an_incomplete_classic_walk_does_not_fall_back() {
+        let mut agent = Agent::new(&ocnos_rows()).stalling_under(oids::lldp::LLDP_MIB);
+
+        let got = query_lldp_neighbors(&mut agent, ip()).await.unwrap();
+
+        assert!(
+            got.records.is_empty(),
+            "V2 rows read past a failed classic walk"
+        );
+        assert!(!got.complete);
+        assert!(!got.local_port_is_if_index);
+    }
+
+    /// The mirror image: on a V2-only device the classic result is complete and *not*
+    /// unsupported, which is the shape the server takes as authority to clear what it holds. A
+    /// V2 walk that stalls must not hand that back — it returns its own incomplete, empty result.
+    #[tokio::test]
+    async fn an_incomplete_v2_walk_is_not_an_authoritative_empty_result() {
+        let mut agent = Agent::new(&ocnos_rows()).stalling_under(oids::lldp_v2::LLDP_V2_MIB);
+
+        let got = query_lldp_neighbors(&mut agent, ip()).await.unwrap();
+
+        assert!(got.records.is_empty());
+        assert!(
+            !got.complete,
+            "a stalled fallback is a failed read, not an empty device"
+        );
+        assert!(!got.unsupported);
+        assert!(got.local_port_is_if_index);
+    }
+
+    /// The V2 index is front-relative and whole: four sub-ids or nothing. Three is the classic
+    /// layout, which the end-relative classic splitter would happily accept and mis-key; five is
+    /// a row from some other table.
+    #[test]
+    fn the_v2_rem_index_needs_exactly_four_sub_ids() {
+        assert_eq!(split_lldp_v2_rem_index(&[0, 10009, 1, 6]), Some((10009, 6)));
+        assert_eq!(split_lldp_v2_rem_index(&[10009, 1, 6]), None);
+        assert_eq!(split_lldp_v2_rem_index(&[0, 10009, 1, 6, 1]), None);
+        assert_eq!(split_lldp_v2_rem_index(&[]), None);
+    }
+
+    /// The same suffix through the classic splitter is the failure the V2 one exists to avoid:
+    /// every neighbour keyed on the destination-address index.
+    #[test]
+    fn the_classic_splitter_mis_keys_a_v2_index() {
+        assert_eq!(split_lldp_rem_index(&[0, 10009, 1, 6]), Some((1, 6)));
+    }
+
+    #[test]
+    fn the_v2_man_addr_index_is_read_with_or_without_a_length() {
+        // OcNOS: no length sub-id, address to the end.
+        assert_eq!(
+            split_lldp_v2_man_addr_index(&[0, 10009, 1, 6, 1, 192, 0, 2, 102]),
+            Some((10009, 6, vec![1, 192, 0, 2, 102]))
+        );
+        // Conformant: the length accounts for exactly what follows.
+        assert_eq!(
+            split_lldp_v2_man_addr_index(&[0, 10009, 1, 6, 1, 4, 192, 0, 2, 102]),
+            Some((10009, 6, vec![1, 192, 0, 2, 102]))
+        );
+        // A subtype with nothing after it: the row exists and carries no address.
+        assert_eq!(
+            split_lldp_v2_man_addr_index(&[0, 3, 1, 4, 2]),
+            Some((3, 4, vec![2]))
+        );
+        assert_eq!(split_lldp_v2_man_addr_index(&[0, 3, 1, 4]), None);
     }
 }

--- a/backend/src/daemon/discovery/integration/snmp/sim/devices/mod.rs
+++ b/backend/src/daemon/discovery/integration/snmp/sim/devices/mod.rs
@@ -26,6 +26,7 @@ pub mod switch_flaky_01;
 pub mod switch_macport_01;
 pub mod switch_mute_01;
 pub mod switch_netgear_01;
+pub mod switch_ocnos_01;
 pub mod switch_omada_01;
 pub mod switch_stuck_01;
 pub mod switch_tplink_01;
@@ -65,5 +66,6 @@ pub fn all() -> Vec<SimDevice> {
         switch_stuck_01::device(),
         switch_dell_01::device(),
         switch_cisco_01::device(),
+        switch_ocnos_01::device(),
     ]
 }

--- a/backend/src/daemon/discovery/integration/snmp/sim/devices/switch_ocnos_01.rs
+++ b/backend/src/daemon/discovery/integration/snmp/sim/devices/switch_ocnos_01.rs
@@ -1,0 +1,251 @@
+use std::net::Ipv4Addr;
+
+use crate::daemon::discovery::integration::snmp::sim::lldp::{
+    Advertised, LldpTable, LocalPort, RemoteNeighbour, V2,
+};
+use crate::daemon::discovery::integration::snmp::sim::mibs::BridgeTable;
+use crate::daemon::discovery::integration::snmp::sim::tables::{IfRow, IfTable};
+use crate::daemon::discovery::integration::snmp::sim::transport::Handler;
+use crate::daemon::discovery::integration::snmp::sim::{Purpose, SimDevice, Tables};
+use crate::daemon::discovery::integration::snmp::types::SystemInfo;
+use crate::server::credentials::r#impl::types::CredentialType;
+use crate::server::interfaces::r#impl::base::if_type;
+use crate::server::lldp::{LldpChassisId, LldpPortId};
+
+use super::inline;
+
+/// Modelled on a UfiSpace S9600-32X running IP Infusion OcNOS 7.0.1, from an `snmpwalk` of the
+/// real switch (GH #688). Identifiers are rewritten for the lab; the structure is the device's
+/// own: a management port at ifIndex 3, thirty-two 100G ports at 10001, 10005, … 10125, and an
+/// LLDP-V2-MIB with three neighbours whose rows are keyed by those ifIndex values.
+pub fn device() -> SimDevice {
+    SimDevice {
+        name: "switch-ocnos-01",
+        ip: Ipv4Addr::new(192, 168, 7, 252),
+        purpose: Purpose::Regression {
+            issue: "#688",
+            defect: "serves LLDP-V2-MIB only: classic lldpRemTable is absent, so the walk finds no neighbours and the device contributes no L2 edges",
+        },
+        credential: CredentialType::SnmpV2c {
+            community: inline("netdefault"),
+        },
+        system: SystemInfo {
+            sys_descr: Some(
+                "Hardware Model:UFI_S9600-32X, Software version: OcNOS,7.0.1.60".into(),
+            ),
+            sys_object_id: Some("1.3.6.1.4.1.36673.100.1.2.1.1.2.52257.2.19".into()),
+            sys_name: Some("switch-ocnos-01".into()),
+            sys_location: Some("Lab".into()),
+            sys_contact: Some("netops@example.com".into()),
+            sys_services: Some(14),
+            sys_uptime: None,
+            // Published from the ifTable at emission, never stored.
+            if_number: None,
+        },
+        tables: tables(),
+        arp_handler: Handler::Normal,
+        suppresses: Vec::new(),
+    }
+}
+
+fn tables() -> Tables {
+    Tables {
+        if_table: Some(if_table()),
+        lldp: Some(lldp_table()),
+        bridge: bridge_table(),
+        ..Default::default()
+    }
+}
+
+/// The management port's address, which is also the chassis id the switch advertises.
+const CHASSIS_MAC: &str = "00:1a:2b:6e:ee:70";
+
+/// The ifIndex of front-panel port `ceN`. OcNOS numbers them 10001 + 4N: the real walk lists
+/// 10001, 10005, … 10125, with nothing in between, so the neighbour indices below (10009 is
+/// `ce2`, 10073 is `ce18`) are only meaningful against a table with the same gaps.
+fn ce_if_index(n: i32) -> i32 {
+    10001 + 4 * n
+}
+
+/// The two fabric uplinks, `ce2` and `ce18` — the only front-panel ports that are up.
+const UPLINK_CE2: i32 = 10009;
+const UPLINK_CE18: i32 = 10073;
+
+/// The hardware address of front-panel port `ceN`, consecutive from the chassis address.
+fn ce_mac(n: i32) -> String {
+    format!("00:1a:2b:6e:ee:{:02x}", 0x71 + n)
+}
+
+pub fn if_table() -> IfTable {
+    let mut rows = vec![
+        IfRow::virtual_if(1, "lo", if_type::SOFTWARE_LOOPBACK)
+            .mtu(16436)
+            .name("lo")
+            .high_speed(),
+        IfRow::port(3, "eth0", Some(CHASSIS_MAC.parse().unwrap()))
+            .name("eth0")
+            .high_speed(),
+    ];
+    for n in 0..32 {
+        let mut port = IfRow::port(
+            ce_if_index(n),
+            &format!("ce{n}"),
+            Some(ce_mac(n).parse().unwrap()),
+        )
+        .speed(100_000_000_000)
+        .name(&format!("ce{n}"))
+        .high_speed();
+        // Only the two uplinks are up; the other thirty ports have nothing plugged in.
+        if ce_if_index(n) != UPLINK_CE2 && ce_if_index(n) != UPLINK_CE18 {
+            port = port.oper_down();
+        }
+        rows.push(port);
+    }
+    // The real walk also lists loopbacks and a sub-interface (`lo.management`,
+    // `lo.INTERNET-VRF`, `loopback10`, `ce10.20`). They carry no LLDP and no MAC of their own,
+    // so they are left out rather than modelled.
+    IfTable::new(rows)
+}
+
+pub fn lldp_table() -> LldpTable {
+    LldpTable::new(
+        Advertised::octets(LldpChassisId::MacAddress(CHASSIS_MAC.into())),
+        "switch-ocnos-01",
+    )
+    .in_mib(&V2)
+    .sys_desc("Hardware Model:UFI_S9600-32X, Software version: OcNOS,7.0.1.60")
+    // `lldpV2LocPortTable` is keyed by ifIndex and lists every port, each identifying itself
+    // by its own MAC — the same thirty-three rows as the walk. The daemon never reads it on
+    // the V2 path; it is here so the served subtree is the device's, not a subset of it.
+    .local_ports(local_ports())
+    .neighbours(vec![
+        // The management port, cabled to the lab's core switch. The remote index is 4, not 1:
+        // OcNOS numbers `lldpV2RemIndex` across the whole device rather than per port, and a
+        // fixture with every index at 1 would not catch a splitter that read the wrong sub-id.
+        RemoteNeighbour::new(
+            3,
+            Advertised::octets(LldpChassisId::MacAddress("00:1a:2b:00:10:00".into())),
+            Advertised::octets(LldpPortId::LocallyAssigned("Ethernet5".into())),
+        )
+        .index(4)
+        .port_desc("S9600-32X : eth0")
+        .sys_name("switch-core-01")
+        .sys_desc("Cisco IOS Software, C2960"),
+        // Two fabric uplinks to switches outside this lab. Their port descriptions are a single
+        // space, which is what the real far ends send.
+        RemoteNeighbour::new(
+            UPLINK_CE2 as u32,
+            Advertised::octets(LldpChassisId::MacAddress("00:1a:2b:40:e9:ca".into())),
+            Advertised::octets(LldpPortId::InterfaceName("swp5".into())),
+        )
+        .index(6)
+        .port_desc(" ")
+        .sys_name("switch-arcos-01")
+        .sys_desc("Arrcus Operating System (ArcOS)"),
+        RemoteNeighbour::new(
+            UPLINK_CE18 as u32,
+            Advertised::octets(LldpChassisId::MacAddress("00:1a:2b:40:d4:ca".into())),
+            Advertised::octets(LldpPortId::InterfaceName("swp5".into())),
+        )
+        .index(2)
+        .port_desc(" ")
+        .sys_name("switch-arcos-02")
+        .sys_desc("Arrcus Operating System (ArcOS)"),
+    ])
+}
+
+fn local_ports() -> Vec<LocalPort> {
+    let mut ports = vec![
+        LocalPort::new(
+            3,
+            Advertised::octets(LldpPortId::MacAddress(CHASSIS_MAC.into())),
+        )
+        .desc("eth0"),
+    ];
+    ports.extend((0..32).map(|n| {
+        LocalPort::new(
+            ce_if_index(n) as u32,
+            Advertised::octets(LldpPortId::MacAddress(ce_mac(n))),
+        )
+        .desc(&format!("ce{n}"))
+    }));
+    ports
+}
+
+pub fn bridge_table() -> BridgeTable {
+    BridgeTable::derived()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::daemon::discovery::integration::snmp::sim::harness;
+
+    /// GH #688: a device that serves only the LLDP-V2-MIB.
+    ///
+    /// Its classic `lldpRemTable` is absent, so before the fallback the walk found no neighbours
+    /// and the device contributed no L2 edges at all. The V2 rows are keyed
+    /// `timeMark.localIfIndex.destMacIndex.remIndex`, and the local identifier is a real ifIndex
+    /// — so the neighbours have to land on 10009 and 10073 directly, not be translated through a
+    /// `lldpLocPortTable` the device does not serve, and not be collapsed onto the
+    /// destination-address index by a splitter that reads the classic layout off the end.
+    #[tokio::test]
+    async fn v2_only_neighbours_are_built_on_their_real_if_index() {
+        let scan = harness::scan("switch-ocnos-01").await;
+
+        assert_eq!(
+            scan.neighbours.records.len(),
+            3,
+            "the V2 table must be read when the classic one is absent"
+        );
+        assert!(scan.neighbours.complete);
+        assert!(!scan.neighbours.unsupported);
+        assert_eq!(scan.neighbours.discarded, 0);
+        assert!(
+            scan.neighbours.local_port_is_if_index,
+            "a V2 result must tell the caller its ports are already ifIndex values"
+        );
+
+        // Each neighbour sits on the ifIndex the device keyed it by, and each is an interface the
+        // device actually has.
+        let mut on = scan
+            .neighbours
+            .records
+            .iter()
+            .map(|n| n.local_port_index)
+            .collect::<Vec<_>>();
+        on.sort_unstable();
+        assert_eq!(on, vec![3, 10009, 10073]);
+        assert_eq!(scan.interface(10009).if_name.as_deref(), Some("ce2"));
+        assert_eq!(scan.interface(10073).if_name.as_deref(), Some("ce18"));
+        assert_eq!(scan.local_port_outcome.unmatched, 0);
+        assert_eq!(scan.local_port_outcome.dropped, 0);
+        assert_eq!(scan.dropped_neighbours, 0);
+
+        assert_eq!(
+            scan.neighbour_named("switch-arcos-01").local_port_index,
+            10009
+        );
+        assert_eq!(scan.neighbour_named("switch-core-01").local_port_index, 3);
+    }
+
+    /// The classic `lldpLocPortTable` is not served, and nothing on this path may depend on it.
+    #[tokio::test]
+    async fn it_serves_no_classic_lldp_tables_at_all() {
+        let scan = harness::scan("switch-ocnos-01").await;
+
+        assert!(
+            scan.local_ports.is_empty(),
+            "a classic local-port row would mean the device is not V2-only"
+        );
+        // lo, eth0 and thirty-two front-panel ports; only the two uplinks are up.
+        assert_eq!(scan.if_table.entries.len(), 34);
+        let up: Vec<i32> = scan
+            .if_table
+            .entries
+            .iter()
+            .filter(|e| e.if_index >= 10001 && e.if_oper_status == Some(1))
+            .map(|e| e.if_index)
+            .collect();
+        assert_eq!(up, vec![10009, 10073]);
+    }
+}

--- a/backend/src/daemon/discovery/integration/snmp/sim/harness.rs
+++ b/backend/src/daemon/discovery/integration/snmp/sim/harness.rs
@@ -109,8 +109,16 @@ pub async fn collect(device: &SimDevice) -> Collected {
     let mut neighbours = query_lldp_neighbors(&mut agent, ip)
         .await
         .unwrap_or_default();
-    let local_port_outcome =
-        remap_lldp_local_ports(&mut neighbours.records, &local_ports, &if_table.entries);
+    // As in `execute`: neighbours read from the LLDP-V2-MIB are keyed by ifIndex already and are
+    // not remapped (GH #688).
+    let local_port_outcome = if neighbours.local_port_is_if_index {
+        LocalPortOutcome {
+            unmatched: 0,
+            dropped: count_dropped_neighbours(&neighbours.records, &local_ports, &if_table.entries),
+        }
+    } else {
+        remap_lldp_local_ports(&mut neighbours.records, &local_ports, &if_table.entries)
+    };
     let dropped_neighbours =
         count_dropped_neighbours(&neighbours.records, &local_ports, &if_table.entries);
 

--- a/backend/src/daemon/discovery/integration/snmp/sim/lldp.rs
+++ b/backend/src/daemon/discovery/integration/snmp/sim/lldp.rs
@@ -14,7 +14,7 @@
 //! of those removes coverage rather than fixing anything.
 
 use super::wire::{MacEncoding, PassValue, Row};
-use crate::daemon::discovery::integration::snmp::oids::lldp;
+use crate::daemon::discovery::integration::snmp::oids::{lldp, lldp_v2};
 use crate::server::lldp::{LldpChassisId, LldpPortId};
 
 /// Which LLDP MIB a simulated table serves.
@@ -25,10 +25,10 @@ use crate::server::lldp::{LldpChassisId, LldpPortId};
 /// the lab has to be able to describe it — which means the OIDs and the index layout are values
 /// here rather than constants baked into `wire_rows`.
 ///
-/// Only [`CLASSIC`] exists today. A second one is a table of constants plus an index composer;
-/// nothing else in the simulator needs to know it arrived — `data_files` and `registrations`
-/// derive the filename and the served subtree from `root`/`file_suffix`, and `SimAgent` serves
-/// whatever it is registered for.
+/// [`CLASSIC`] and [`V2`] are each a table of constants plus an index composer; nothing else in
+/// the simulator knows which a device serves — `data_files` and `registrations` derive the
+/// filename and the served subtree from `root`/`file_suffix`, and `SimAgent` serves whatever it
+/// is registered for.
 #[derive(Debug)]
 pub struct SimLldpMib {
     /// Subtree the agent registers, and the whole of what a walk of this MIB can reach.
@@ -90,6 +90,56 @@ pub static CLASSIC: SimLldpMib = SimLldpMib {
     },
     rem_suffix: classic_rem_suffix,
 };
+
+/// The LLDP-V2-MIB, `1.3.111.2.802.1.1.13` (GH #688).
+///
+/// The local tables keep the classic column numbering; the remote entry inserts
+/// `lldpV2RemLocalIfIndex` as column 2, so every remote column sits one above its classic
+/// counterpart, and its index gains a fourth sub-id — see [`v2_rem_suffix`].
+pub static V2: SimLldpMib = SimLldpMib {
+    root: lldp_v2::LLDP_V2_MIB,
+    file_suffix: "lldpv2",
+    local: SimLldpLocalColumns {
+        chassis_id_subtype: lldp_v2::local::LLDP_V2_LOC_CHASSIS_ID_SUBTYPE,
+        chassis_id: lldp_v2::local::LLDP_V2_LOC_CHASSIS_ID,
+        sys_name: lldp_v2::local::LLDP_V2_LOC_SYS_NAME,
+        sys_desc: lldp_v2::local::LLDP_V2_LOC_SYS_DESC,
+        port_id_subtype: lldp_v2::local::LLDP_V2_LOC_PORT_ID_SUBTYPE,
+        port_id: lldp_v2::local::LLDP_V2_LOC_PORT_ID,
+        port_desc: lldp_v2::local::LLDP_V2_LOC_PORT_DESC,
+    },
+    remote: SimLldpRemoteColumns {
+        chassis_id_subtype: lldp_v2::remote::entry::LLDP_V2_REM_CHASSIS_ID_SUBTYPE,
+        chassis_id: lldp_v2::remote::entry::LLDP_V2_REM_CHASSIS_ID,
+        port_id_subtype: lldp_v2::remote::entry::LLDP_V2_REM_PORT_ID_SUBTYPE,
+        port_id: lldp_v2::remote::entry::LLDP_V2_REM_PORT_ID,
+        port_desc: lldp_v2::remote::entry::LLDP_V2_REM_PORT_DESC,
+        sys_name: lldp_v2::remote::entry::LLDP_V2_REM_SYS_NAME,
+        sys_desc: lldp_v2::remote::entry::LLDP_V2_REM_SYS_DESC,
+    },
+    rem_suffix: v2_rem_suffix,
+};
+
+/// The `lldpV2DestAddressTable` row every neighbour in the lab is learned through: 1, the
+/// nearest-bridge group address, which is the only destination the firmware this models uses.
+const NEAREST_BRIDGE_DEST_INDEX: u64 = 1;
+
+/// `lldpV2RemTimeMark.lldpV2RemLocalIfIndex.lldpV2RemLocalDestMACAddress.lldpV2RemIndex` — four
+/// sub-ids, the second a real ifIndex and the third a row pointer, not six octets of MAC. No V2
+/// firmware has been seen omitting the time mark, so [`TimeMark::Omitted`] serves it as 0 rather
+/// than inventing a three-sub-id layout the daemon deliberately rejects.
+fn v2_rem_suffix(neighbour: &RemoteNeighbour) -> Vec<u64> {
+    let mark = match neighbour.time_mark {
+        TimeMark::At(mark) => mark as u64,
+        TimeMark::Omitted => 0,
+    };
+    vec![
+        mark,
+        neighbour.local_port as u64,
+        NEAREST_BRIDGE_DEST_INDEX,
+        neighbour.index as u64,
+    ]
+}
 
 /// `lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex` — three sub-ids, or two where the firmware
 /// omits the time mark (GH #668).
@@ -244,7 +294,7 @@ impl RemoteNeighbour {
                 }
                 Some(ChassisDefect::SubtypeWrongType(text)) => {
                     rows.push(Row::at(
-                        lldp::remote::entry::LLDP_REM_CHASSIS_ID_SUBTYPE,
+                        mib.remote.chassis_id_subtype,
                         &suffix,
                         PassValue::Str(text.to_string()),
                     ));
@@ -256,7 +306,7 @@ impl RemoteNeighbour {
                 }
                 None => {
                     rows.push(Row::at(
-                        lldp::remote::entry::LLDP_REM_CHASSIS_ID_SUBTYPE,
+                        mib.remote.chassis_id_subtype,
                         &suffix,
                         PassValue::Integer(subtype as i64),
                     ));
@@ -476,32 +526,63 @@ mod tests {
     /// legitimately renamed.
     #[test]
     fn a_table_serves_the_oids_its_own_mib_names() {
-        let rows = LldpTable::new(
-            Advertised::octets(LldpChassisId::MacAddress("00:11:22:33:44:55".into())),
-            "switch-somewhere",
-        )
-        .local_ports(vec![LocalPort::new(
-            1,
-            Advertised::text(
-                LldpPortId::InterfaceName("Gi0/1".into()),
-                MacEncoding::AsciiLower,
-            ),
-        )])
-        .neighbours(vec![RemoteNeighbour::new(
-            1,
-            Advertised::octets(LldpChassisId::MacAddress("00:aa:bb:cc:dd:ee".into())),
-            Advertised::text(
-                LldpPortId::InterfaceName("Gi0/2".into()),
-                MacEncoding::AsciiLower,
-            ),
-        )])
-        .wire_rows();
+        for mib in [&CLASSIC, &V2] {
+            let rows = LldpTable::new(
+                Advertised::octets(LldpChassisId::MacAddress("00:11:22:33:44:55".into())),
+                "switch-somewhere",
+            )
+            .in_mib(mib)
+            .local_ports(vec![LocalPort::new(
+                1,
+                Advertised::text(
+                    LldpPortId::InterfaceName("Gi0/1".into()),
+                    MacEncoding::AsciiLower,
+                ),
+            )])
+            .neighbours(vec![
+                RemoteNeighbour::new(
+                    1,
+                    Advertised::octets(LldpChassisId::MacAddress("00:aa:bb:cc:dd:ee".into())),
+                    Advertised::text(
+                        LldpPortId::InterfaceName("Gi0/2".into()),
+                        MacEncoding::AsciiLower,
+                    ),
+                ),
+                // The wrong-typed subtype is the one row that used to name a classic column
+                // regardless of the MIB the table was in.
+                RemoteNeighbour::new(
+                    2,
+                    Advertised::octets(LldpChassisId::MacAddress("00:aa:bb:cc:dd:ef".into())),
+                    Advertised::text(
+                        LldpPortId::InterfaceName("Gi0/3".into()),
+                        MacEncoding::AsciiLower,
+                    ),
+                )
+                .defect(ChassisDefect::SubtypeWrongType("macAddress")),
+            ])
+            .wire_rows();
 
-        assert!(!rows.is_empty());
-        let root = crate::daemon::discovery::integration::snmp::oids::oid_parts(CLASSIC.root);
-        assert!(
-            rows.iter().all(|row| row.oid.starts_with(&root)),
-            "every row must fall under the MIB the table names"
+            assert!(!rows.is_empty());
+            let root = crate::daemon::discovery::integration::snmp::oids::oid_parts(mib.root);
+            assert!(
+                rows.iter().all(|row| row.oid.starts_with(&root)),
+                "every row must fall under {}, the MIB the table names",
+                mib.root
+            );
+        }
+    }
+
+    /// The V2 index has four sub-ids, the third of them the destination-address row rather than
+    /// anything the neighbour carries. It is the shape the classic end-relative splitter mis-reads
+    /// (GH #688), so a fixture that served three would not be testing the fallback at all.
+    #[test]
+    fn a_v2_neighbour_is_keyed_by_time_mark_if_index_dest_address_and_index() {
+        let rows = RemoteNeighbour::new(10009, chassis(), port())
+            .index(6)
+            .wire_rows(&V2);
+        assert_eq!(
+            suffixes(&rows, lldp_v2::remote::entry::LLDP_V2_REM_CHASSIS_ID),
+            vec![vec![0, 10009, 1, 6]]
         );
     }
 

--- a/tools/snmp/SNMP-TEST-ENV.md
+++ b/tools/snmp/SNMP-TEST-ENV.md
@@ -32,6 +32,7 @@
 | 192.168.7.249 | switch-stuck-01 | v2c | community `netdefault` | ARP table never advances (see below) |
 | 192.168.7.250 | switch-dell-01 | v2c | community `netdefault` | Dell PowerSwitch S4112T-ON, OS10 breakout ports (see below) |
 | 192.168.7.251 | switch-cisco-01 | **v3 only** | user `scanopyctx`, context `vlan-20` | Cisco Catalyst 3850, per-VLAN bridge context (see below) |
+| 192.168.7.252 | switch-ocnos-01 | v2c | community `netdefault` | UfiSpace S9600-32X, IP Infusion OcNOS, LLDP-V2-MIB only (see below) |
 
 **LLDP local-port remap (`.238`/`.239`).** ExtremeXOS reports its `lldpRemTable` local-port index as an `lldpLocPortNum` (1..N) that is a **separate namespace from `ifIndex`** (switch-exos-01 uses ifIndex 1001+, ifName `1:N`), so neighbours only resolve if the daemon walks `lldpLocPortTable` (`1.0.8802.1.1.2.1.3.7`) and suffix-matches `lldpLocPortId` against `ifName`. Before the Issue 2 fix, switch-exos-01 yields **zero** LLDP neighbours. Extreme VOSS (switch-voss-01) reports local-port == ifIndex with `lldpLocPortId` matching `ifName` exactly, so it stays correct on both old and new code — the regression guard for the fix.
 
@@ -198,6 +199,24 @@ Note that `1/0/3` and `1/0/4` name the same far-end device on purpose. The pair 
 **`1/0/2` is unresolvable on purpose.** It advertises a desk phone whose MAC and sysName belong to no device in this lab, so every host tier fails and it is the environment's only source of a non-zero `host_not_found`. That counter is otherwise permanently 0 here, which left the server-side summary that names unmatched far ends with no way to fire. Endpoints exactly like this are what `host_not_found` legitimately consists of on a real network (#668).
 
 > Every far-end value above is checked against what the lab actually reports. An earlier revision used a made-up chassis MAC for switch-netgear-01 and a port (`Gi0/4`) that switch-core-01 does not have; both still appeared to work — one fell through to the sysName tier, the other stopped at a device-level edge — so the profile passed without exercising what it documents. When adding a neighbour here, confirm the far end's `hosts.chassis_id`, `if_name` and `if_index` in the scanned data first.
+
+**A device that serves only the LLDP-V2-MIB (`.252`).** Modelled on a UfiSpace S9600-32X running IP Infusion OcNOS 7.0.1, from an `snmpwalk` of the real switch (#688), identifiers rewritten for the lab. Its LLDP lives under the 802.1AB-2009 root `1.3.111.2.802.1.1.13` and nowhere else: a walk of the classic `1.0.8802.1.1.2.1.4.1` finds nothing, so before the fallback the device contributed no L2 edges at all. Three things differ from every other device here, and each is what the regression test checks:
+
+```
+.1.3.111.2.802.1.1.13.1.4.1.1.5.0.10009.1.6 = INTEGER: 4      # timeMark.ifIndex.destMacIndex.remIndex
+.1.3.111.2.802.1.1.13.1.4.1.1.6.0.10009.1.6 = Hex-STRING: 00 1A 2B 40 E9 CA
+```
+
+- The remote columns sit **one above** their classic numbers (`lldpV2RemLocalIfIndex` is inserted as column 2), so chassis subtype is `.5`, chassis id `.6`, and so on.
+- The row index has **four** sub-ids, the third a row pointer into `lldpV2DestAddressTable` (always 1 here). The classic end-relative parse reads `(1, remIndex)` off that and collapses every neighbour onto port 1.
+- The local identifier is a **real ifIndex** — 3, 10009, 10073 — not an `lldpLocPortNum`, and there is no classic `lldpLocPortTable` to remap through. The daemon must place the neighbours on those interfaces directly.
+
+The interface table is the device's own shape: `eth0` at ifIndex 3 and thirty-two 100G ports `ce0`–`ce31` at 10001, 10005, … 10125, with nothing in between, so the neighbour indices are only meaningful against a table with the same gaps. Verify with:
+
+```bash
+snmpwalk -v2c -c netdefault 192.168.7.252 1.0.8802.1.1.2.1.4.1.1.4    # nothing under the classic root
+snmpwalk -v2c -c netdefault 192.168.7.252 1.3.111.2.802.1.1.13.1.4.1.1.6   # three neighbours, four-part index
+```
 
 > **The NUL half of #668 is not reproducible here.** The same D-Links NUL-terminate their port ids (`lldpRemPortId` arrives as `31 00`, i.e. `"1\0"`), which used to fail the write of the entire host. net-snmp's `pass` protocol is line-based — the handler prints OID, type and value as three lines — so an embedded `0x00` cannot survive the transport and no data file can express it. That half is covered by unit tests instead: `value_to_string`, `LldpPortId::from_snmp`, and `PgText`/`PgJson` in `server/shared/storage/pg_value.rs`.
 

--- a/tools/snmp/snmp-test-env.sh
+++ b/tools/snmp/snmp-test-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# SNMP Test Environment — manages 22 snmpd instances on a Proxmox LXC
-# Subnet: 192.168.4.0/22 (hosts at 192.168.7.230–251)
+# SNMP Test Environment — manages 23 snmpd instances on a Proxmox LXC
+# Subnet: 192.168.4.0/22 (hosts at 192.168.7.230–252)
 # Usage: tools/snmp/snmp-test-env.sh deploy|verify|status
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
Fixes #688.

## What
Some agents implement only the 802.1AB-2009 **LLDP-V2-MIB** (`1.3.111.2.802.1.1.13`) — IP Infusion OcNOS among them — and contribute no L2 edges because only the classic `1.0.8802.1.1.2` remote table is walked. This adds the V2 MIB as a second `LldpMibProfile` and walks it as a **fallback, never alongside** the classic one.

Per the review notes on the issue:
- **Remote columns are classic+1** (`.5` chassis-id-subtype … `.11` sysDesc); local tables keep classic numbering.
- **Separate front-relative splitter** for `lldpV2RemEntry` (`timeMark.localIfIndex.localDestMACAddress.remIndex`), requiring exactly four sub-ids. `split_lldp_rem_index` is untouched; a test shows what it would have done to a V2 index (every neighbour keyed on the destination-address index).
- **`remap_lldp_local_ports` and the `lldpLocPortTable` walk are skipped** on the V2 path — `lldpV2RemLocalIfIndex` is already an ifIndex. The result carries `local_port_is_if_index` for that; the placement check against the interface table still runs.
- `LldpChassisId` / `LldpPortId` / `from_snmp` are reused as-is; no schema change.

## One deliberate deviation — the gate
The issue suggested gating on `unsupported`. On the device this exists for, that flag is **false**: OcNOS serves the `lldpExtensions` subtree under the classic root, so every classic remote column ends `EndOfSubtree` ("implemented and empty"), never `EndOfMibView` — the walks in the issue body show it. The gate is therefore *classic walk finished with zero rows*, which is wider than `unsupported` and is paid for by every host/printer/empty switch with an implemented-but-empty classic table: eight single-page walks that find nothing. An **incomplete** classic walk never falls back, and an equally empty V2 attempt keeps the classic verdict so a no-LLDP agent stays `unsupported` rather than gaining authority to clear another integration's neighbours. An incomplete V2 walk is likewise returned as non-authoritative rather than laundered into "no neighbours". If you'd rather gate on `unsupported || zero rows` with a narrower cost, it's a one-line change — but on OcNOS it has to include zero rows.

## Simulator
`SimLldpMib::V2` beside `CLASSIC` (own root, `lldpv2` file suffix, shifted columns, four-sub-id `rem_suffix`) and **`switch-ocnos-01`** (`192.168.7.252`, `Purpose::Regression { issue: "#688" }`), built from an `snmpwalk -On` of a UfiSpace S9600-32X on OcNOS 7.0.1.60 with identifiers rewritten: `eth0` at ifIndex 3, `ce0..ce31` at 10001..10125 step 4 with ifXTable names, the full 33-row `lldpV2LocPortTable`, three V2 neighbours on 3/10009/10073 (remIndex 4/6/2, time mark 0, dest-address index 1, subtypes 4 and 7/5/5, the blank `" "` port descriptions the box really sends), and **no classic LLDP tables**. Its regression test drives the real collection path and asserts the neighbours land on 10009/10073 directly. While wiring V2 through the simulator, `RemoteNeighbour::wire_rows` turned out to hard-code the classic chassis-subtype OID instead of `mib.remote.chassis_id_subtype`; fixed, and the own-MIB test now runs against both profiles with a `SubtypeWrongType` neighbour that would have caught it. Classic fixture output is unchanged.

## Tests
- `cargo test --lib -- discovery::integration::snmp` → 166 passed (new: V2-only agent keyed by ifIndex, classic agent never reaches V2, neither-MIB stays unsupported, incomplete classic does not fall back, incomplete V2 is not authoritative, splitter rejects 0/3/5 sub-ids, classic splitter mis-keys V2, man-addr index with/without length; `switch-ocnos-01` device tests; sim `lldp` own-MIB test for both profiles)
- `cargo test --lib -- tests::snmp_sim_resolution` → 7 passed
- `cargo check --features snmp-sim --bin generate-snmp-fixtures` OK; clippy clean in touched files; fmt clean
- Live: the same fallback (earlier form) has been running in our deployment against two OcNOS boxes (S9600-32X and S9510-28DC) and produces their edges.
