### PR TITLE
chore: regenerate db_enum_baseline for v0.17.13

### DIFF
--- a/backend/tests/fixtures/db_enum_baseline.json
+++ b/backend/tests/fixtures/db_enum_baseline.json
@@ -39,6 +39,22 @@
     "SelfHostedStandard",
     "SelfHostedPlus"
   ],
+  "ClaimSource": [
+    "IfNumber",
+    "SysServicesBridgeBit",
+    "LldpLocalIdentity",
+    "Dot1dBaseNumPorts"
+  ],
+  "CredentialQueryPayloadDiscriminants": [
+    "Snmp",
+    "DockerProxy",
+    "DockerSocket",
+    "PodmanProxy",
+    "PodmanSocket",
+    "UnifiController",
+    "InstantOn",
+    "Unknown"
+  ],
   "CredentialType": [
     "SnmpV2c",
     "DockerProxy",
@@ -61,6 +77,50 @@
     "Docker",
     "Unified",
     "Rescan"
+  ],
+  "DiscoveryWarningCode": [
+    "InterfaceSetCutShort",
+    "InterfaceDetailsCutShort",
+    "SnmpWalkEntryCap",
+    "SnmpWalkUnsupported",
+    "SnmpWalkDesynchronised",
+    "SnmpWalkPartialDiscarded",
+    "SnmpWalkPartialRecorded",
+    "SnmpWalkBridgeMibAbsent",
+    "SnmpWalkNoAnswer",
+    "ClaimedCountReadCutShort",
+    "ClaimedCountUnderRead",
+    "ClaimedCapabilityReadCutShort",
+    "ClaimedCapabilityEmpty",
+    "LldpLocalPortDropped",
+    "LldpLocalPortMisplaced",
+    "MalformedNeighboursWalkCutShort",
+    "MalformedNeighboursGhostRows",
+    "MalformedNeighboursIncompleteRecords",
+    "MalformedNeighboursUnexpectedType",
+    "MalformedNeighboursUnreadableIndex",
+    "SnmpCollectedNothing",
+    "VlanRecordingFailed",
+    "CredentialTargetNotScanned",
+    "CredentialTargetNotResponding",
+    "CredentialGateClosed",
+    "CredentialRejected",
+    "CredentialMalformed",
+    "CredentialTlsFailed",
+    "CredentialNotThisService",
+    "CredentialCollectionFailed",
+    "CredentialCollectionTimedOut",
+    "CredentialUnreachable",
+    "CredentialTimedOut",
+    "ScanTimeLimitWithEstimate",
+    "ScanTimeLimit",
+    "LldpNeighbourNotFound",
+    "LldpNeighbourAmbiguous",
+    "LldpPortNoStrategy",
+    "LldpPortNotFound",
+    "LldpPortAmbiguous",
+    "WarningsTruncated",
+    "Unknown"
   ],
   "EdgeStyle": [
     "Straight",
@@ -106,7 +166,8 @@
     "DetectedService",
     "Hostname",
     "Integration",
-    "Manual"
+    "Manual",
+    "DnsSd"
   ],
   "HostVirtualization": [
     "Proxmox",
@@ -135,6 +196,10 @@
     "InterfaceName",
     "AgentCircuitId",
     "LocallyAssigned"
+  ],
+  "MalformedNeighbourConsequence": [
+    "AllLinksLost",
+    "SomeLinksLost"
   ],
   "OnboardingOperationDiscriminants": [
     "OrgCreated",
@@ -167,6 +232,19 @@
   "ServiceVirtualization": [
     "Docker",
     "Podman"
+  ],
+  "SnmpWalkGroup": [
+    "Lldp",
+    "Cdp",
+    "Interfaces",
+    "BridgePortNumbering",
+    "BridgeForwarding",
+    "VlanMembership",
+    "ArpTable",
+    "DeviceInventory",
+    "IpAddresses",
+    "LldpLocalPorts",
+    "VlanNames"
   ],
   "TopologyView": [
     "L2Physical",


### PR DESCRIPTION
Automated baseline refresh after v0.17.13 was published. Merges the new set of DB-backed enum variants into the baseline so the next release cycle's coexistence checks compare against the just-released binary.$'\n\n'Review: confirm the diff matches the enum changes in this release. If a rename shipped with a `#[serde(alias)]`, keep the old name in the fixture manually.