### PR TITLE
chore: regenerate db_enum_baseline for v0.17.14

### DIFF
--- a/backend/tests/fixtures/db_enum_baseline.json
+++ b/backend/tests/fixtures/db_enum_baseline.json
@@ -1,4 +1,20 @@
 {
+  "AttributeSource": [
+    "Unspecified",
+    "OwnAddress",
+    "ServiceMatch",
+    "LldpNeighbourAddress",
+    "CipVendorId",
+    "DnsSdInstanceName",
+    "LldpChassisId",
+    "ReverseDns",
+    "ForwardingTable",
+    "ArpReply",
+    "DaemonSelfReport",
+    "Probe",
+    "Authored",
+    "Manual"
+  ],
   "AuthenticatedEntity": [
     "User",
     "Daemon",
@@ -44,6 +60,49 @@
     "SysServicesBridgeBit",
     "LldpLocalIdentity",
     "Dot1dBaseNumPorts"
+  ],
+  "ClientProbe": [
+    "Docker",
+    "Gnmi",
+    "Podman",
+    "Snmp",
+    "UnifiController",
+    "InstantOn",
+    "ModbusTcp",
+    "OpcUa",
+    "EtherNetIp",
+    "Sip",
+    "Ssh",
+    "Ftp",
+    "Telnet",
+    "Rtsp",
+    "Nut",
+    "ZabbixAgent",
+    "CheckMkAgent",
+    "Smb",
+    "Ldap",
+    "Kerberos",
+    "MySql",
+    "PostgreSql",
+    "MsSql",
+    "MongoDb",
+    "Redis",
+    "Cassandra",
+    "Kafka",
+    "Amqp",
+    "Mqtt",
+    "OracleTns",
+    "Rdp",
+    "Nfs",
+    "DnsTcp",
+    "DockerSwarm",
+    "Tls",
+    "Ike",
+    "OpenVpn",
+    "Zmtp",
+    "Bacula",
+    "BeszelAgent",
+    "H323"
   ],
   "CredentialQueryPayloadDiscriminants": [
     "Snmp",
@@ -120,7 +179,11 @@
     "LldpPortNotFound",
     "LldpPortAmbiguous",
     "WarningsTruncated",
-    "Unknown"
+    "Unknown",
+    "LldpLocalPortDroppedReadCutShort",
+    "ConnectionsWithoutProtocolResponse",
+    "ProvisionalSubnetInferred",
+    "NeighbourResolutionIncomplete"
   ],
   "EdgeStyle": [
     "Straight",
@@ -157,17 +220,8 @@
     "System",
     "Discovery",
     "DiscoveryWithMatch",
-    "Unknown"
-  ],
-  "HostNameSource": [
-    "Unnamed",
-    "Unspecified",
-    "Ip",
-    "DetectedService",
-    "Hostname",
-    "Integration",
-    "Manual",
-    "DnsSd"
+    "Unknown",
+    "Inferred"
   ],
   "HostVirtualization": [
     "Proxmox",


### PR DESCRIPTION
Automated baseline refresh after v0.17.14 was published. Merges the new set of DB-backed enum variants into the baseline so the next release cycle's coexistence checks compare against the just-released binary.$'\n\n'Review: confirm the diff matches the enum changes in this release. If a rename shipped with a `#[serde(alias)]`, keep the old name in the fixture manually.